### PR TITLE
Set all PIS layers as queriable

### DIFF
--- a/gs_data_dir_26/workspaces/destination/destination/pis_1/layer.xml
+++ b/gs_data_dir_26/workspaces/destination/destination/pis_1/layer.xml
@@ -8,7 +8,7 @@
   <resource class="featureType">
     <id>FeatureTypeInfoImpl-e1c6fd1:14ededdc0ad:-7ffa</id>
   </resource>
-  <queryable>false</queryable>
+  <queryable>true</queryable>
   <opaque>true</opaque>
   <attribution>
     <logoWidth>0</logoWidth>


### PR DESCRIPTION
If any layer in the layergroup is not queriable, the whole group is not queriable.
PIS layers are all vector layers and can be queriable.